### PR TITLE
fix: bump axum to 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,43 +272,12 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.5.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acee9fd5073ab6b045a275b3e709c163dd36c90685219cb21804a147b58dba43"
-dependencies = [
- "async-trait",
- "axum-core 0.2.9",
- "bitflags",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "itoa",
- "matchit 0.5.0",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-http",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "744864363a200a5e724a7e61bc8c11b6628cf2e3ec519c8a1a48e609a8156b40"
 dependencies = [
  "async-trait",
- "axum-core 0.3.0",
+ "axum-core",
  "bitflags",
  "bytes",
  "futures-util",
@@ -316,32 +285,20 @@ dependencies = [
  "http-body",
  "hyper",
  "itoa",
- "matchit 0.6.0",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
  "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper",
+ "tokio",
  "tower",
  "tower-http",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e5939e02c56fecd5c017c37df4238c0a839fa76b7f97acdd7efb804fd181cc"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "mime",
  "tower-layer",
  "tower-service",
 ]
@@ -1342,7 +1299,7 @@ version = "0.2.1"
 dependencies = [
  "arc-swap",
  "axon-protocol",
- "axum 0.5.17",
+ "axum",
  "beef",
  "common-apm-derive",
  "derive_more",
@@ -3952,12 +3909,6 @@ checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchit"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
-
-[[package]]
-name = "matchit"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dfc802da7b1cf80aefffa0c7b2f77247c8b32206cc83c270b61264f5b360a80"
@@ -5838,6 +5789,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "184c643044780f7ceb59104cef98a5a6f12cb2288a7bc701ab93a362b49fd47d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6688,7 +6648,7 @@ checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum 0.6.0",
+ "axum",
  "base64 0.13.1",
  "bytes",
  "futures-core",

--- a/common/apm/Cargo.toml
+++ b/common/apm/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 arc-swap = "1.5"
-axum = "0.5"
+axum = "0.6"
 beef = "0.5"
 derive_more = "0.99"
 hyper = { version = "0.14", features = ["http1", "server"] }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [ ] Cargo Clippy
- [ ] Coverage Test
- [ ] E2E Tests
- [ ] Code Format
- [ ] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
