### PR TITLE
ci: add a workflow to build docker image

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -1,0 +1,35 @@
+name: Build docker image
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      dispatch:
+        type: string
+        description: "The tag name for docker images"
+        required: true
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      output-sha: ${{ steps.escape_multiple_lines_test_inputs.outputs.result }}
+    steps:
+      - name: output tag name for image
+        id: tag_name
+        run: |
+          if [ ${{ github.event_name }} == 'push' ]; then
+            export tag_name=`echo ${{ github.ref }} | awk -F '/' '{print $3}'`
+          fi
+          if [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
+            export tag_name=${{ github.event.inputs.dispatch }}
+          fi
+          echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
+      - name: Git checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref || 'main' }}
+      - name: build and push docker image
+        run: |
+          echo "${{ github.ref }}"
+          echo ${{ steps.tag_name.outputs.tag_name }}

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,8 +1,8 @@
 name: Cargo Clippy
 on:
-  push:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
   pull_request:
     types: [ opened, synchronize, reopened ]
   workflow_dispatch:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,8 +1,8 @@
 name: Coverage Test
 on:
-  push:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
   workflow_dispatch:
     inputs:
       dispatch:

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -1,8 +1,8 @@
 name: E2E Tests
 on:
-  push:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
   pull_request:
     types: [ opened, synchronize, reopened ]
   workflow_dispatch:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -1,8 +1,8 @@
 name: Code Format
 on:
-  push:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
   workflow_dispatch:
     inputs:
       dispatch:

--- a/.github/workflows/openzeppelin_test_11.yml
+++ b/.github/workflows/openzeppelin_test_11.yml
@@ -1,9 +1,9 @@
 name: OCT 11
 
 on:
-  push:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
   workflow_dispatch:
     inputs:
       dispatch:

--- a/.github/workflows/openzeppelin_test_16_19.yml
+++ b/.github/workflows/openzeppelin_test_16_19.yml
@@ -1,9 +1,9 @@
 name: OCT 16-19
 
 on:
-  push:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
   workflow_dispatch:
     inputs:
       dispatch:

--- a/.github/workflows/openzeppelin_test_1_5_and_12_15.yml
+++ b/.github/workflows/openzeppelin_test_1_5_and_12_15.yml
@@ -1,9 +1,9 @@
 name: OCT 1-5 And 12-15
 
 on:
-  push:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
   workflow_dispatch:
     inputs:
       dispatch:

--- a/.github/workflows/openzeppelin_test_6_10.yml
+++ b/.github/workflows/openzeppelin_test_6_10.yml
@@ -1,9 +1,9 @@
 name: OCT 6-10
 
 on:
-  push:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
   workflow_dispatch:
     inputs:
       dispatch:

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -1,8 +1,8 @@
 name: Unit Tests
 on:
-  push:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
   pull_request:
     types: [ opened, synchronize, reopened ]
   workflow_dispatch:

--- a/.github/workflows/v3_core_test.yml
+++ b/.github/workflows/v3_core_test.yml
@@ -1,9 +1,9 @@
 name: v3 Core Tests
 
 on:
-  push:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
   workflow_dispatch:
     inputs:
       dispatch:

--- a/.github/workflows/web3_compatible.yml
+++ b/.github/workflows/web3_compatible.yml
@@ -1,9 +1,9 @@
 name: Web3 Compatible Tests
 
 on:
-  push:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
   pull_request:
     types: [ opened, synchronize, reopened ]
   workflow_dispatch:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [ ] Cargo Clippy
- [ ] Coverage Test
- [ ] E2E Tests
- [ ] Code Format
- [ ] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
