### PR TITLE
ci: Commite message check

### DIFF
--- a/.github/workflows/generate_changlog_file.yml
+++ b/.github/workflows/generate_changlog_file.yml
@@ -38,10 +38,14 @@ jobs:
       with:
         token: ${{ secrets.TOKEN }}
         signoff: false
+<<<<<<< HEAD
         commit-message: "docs: automated update CHANGELOG.md"
         branch: bot-${{ github.repository }}
         title: "docs: automated update CHANGELOG.md"
         commit-message: "feat: automated pr to change config files"
+=======
+        commit-message: "docs: automated update CHANGELOG.mds"
+>>>>>>> 94bbc12 (ci: update commit message)
         branch: bot-${{ github.repository }}
         title: "feat: automated pr to change log"
         body: "automated pr to change log"

--- a/.github/workflows/generate_changlog_file.yml
+++ b/.github/workflows/generate_changlog_file.yml
@@ -17,10 +17,14 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           headerLabel: "# 📑 Changelog"
 <<<<<<< HEAD
+<<<<<<< HEAD
           addSections: '{"documentation":{"prefix":"### 📖 Documentation","labels":["document"]},"Features":{"prefix":"### 🚀 Features","labels":["feature"]},"Enhancement":{"prefix":"### 🔥 Enhancement","labels":["enhancement"]},"bugfix":{"prefix":"🐛 Bug Fixes","labels":["bugfix"]},"refactor":{"prefix":"### 🐝  refactor","labels":["refactor"]},"chore":{"prefix":"### 🧰 Chore","labels":["chore"]},"Otherchanges":{"prefix":"✨ Other changes","labels":[""]},"dependencies":{"prefix":"⬆️ Dependency Updates","labels":["dependencies"]},"style":{"prefix":"🌈 Style","labels":["style"]}}'
 =======
           addSections: '{"documentation":{"prefix":"### 📖 Documentation","labels":["document"]},"Features":{"prefix":"### 🚀 Features","labels":["feature"]},"Enhancement":{"prefix":"### 🚀 Enhancement","labels":["enhancement"]},"bugfix":{"prefix":"🐛 Bug Fixes","labels":["bugfix"]},"refactor":{"prefix":"### 🐝  refactor","labels":["refactor"]},"chore":{"prefix":"### 🧰 Chore","labels":["chore"]},"Otherchanges":{"prefix":"✨ Other changes","labels":[""]},"dependencies":{"prefix":"⬆️ Dependency Updates","labels":["dependencies"]},"style":{"prefix":"🌈 Style","labels":["style"]}}'
 >>>>>>> c3ddb29 (ci: workflow to generate changlog)
+=======
+          addSections: '{"documentation":{"prefix":"### 📖 Documentation","labels":["document"]},"Features":{"prefix":"### 🚀 Features","labels":["feature"]},"Enhancement":{"prefix":"### 🔥 Enhancement","labels":["enhancement"]},"bugfix":{"prefix":"🐛 Bug Fixes","labels":["bugfix"]},"refactor":{"prefix":"### 🐝  refactor","labels":["refactor"]},"chore":{"prefix":"### 🧰 Chore","labels":["chore"]},"Otherchanges":{"prefix":"✨ Other changes","labels":[""]},"dependencies":{"prefix":"⬆️ Dependency Updates","labels":["dependencies"]},"style":{"prefix":"🌈 Style","labels":["style"]}}'
+>>>>>>> 0308bf9 (ci: update prefix image)
           author: true
           compareLink: true
           stripGeneratorNotice: true
@@ -39,6 +43,7 @@ jobs:
         token: ${{ secrets.TOKEN }}
         signoff: false
 <<<<<<< HEAD
+<<<<<<< HEAD
         commit-message: "docs: automated update CHANGELOG.md"
         branch: bot-${{ github.repository }}
         title: "docs: automated update CHANGELOG.md"
@@ -46,6 +51,9 @@ jobs:
 =======
         commit-message: "docs: automated update CHANGELOG.mds"
 >>>>>>> 94bbc12 (ci: update commit message)
+=======
+        commit-message: "docs: automated update CHANGELOG.md"
+>>>>>>> 0308bf9 (ci: update prefix image)
         branch: bot-${{ github.repository }}
         title: "docs: automated update CHANGELOG.md"
         body: "automated pr to change log"

--- a/.github/workflows/generate_changlog_file.yml
+++ b/.github/workflows/generate_changlog_file.yml
@@ -16,15 +16,7 @@ jobs:
       with:
           token: ${{ secrets.GITHUB_TOKEN }}
           headerLabel: "# 📑 Changelog"
-<<<<<<< HEAD
-<<<<<<< HEAD
           addSections: '{"documentation":{"prefix":"### 📖 Documentation","labels":["document"]},"Features":{"prefix":"### 🚀 Features","labels":["feature"]},"Enhancement":{"prefix":"### 🔥 Enhancement","labels":["enhancement"]},"bugfix":{"prefix":"🐛 Bug Fixes","labels":["bugfix"]},"refactor":{"prefix":"### 🐝  refactor","labels":["refactor"]},"chore":{"prefix":"### 🧰 Chore","labels":["chore"]},"Otherchanges":{"prefix":"✨ Other changes","labels":[""]},"dependencies":{"prefix":"⬆️ Dependency Updates","labels":["dependencies"]},"style":{"prefix":"🌈 Style","labels":["style"]}}'
-=======
-          addSections: '{"documentation":{"prefix":"### 📖 Documentation","labels":["document"]},"Features":{"prefix":"### 🚀 Features","labels":["feature"]},"Enhancement":{"prefix":"### 🚀 Enhancement","labels":["enhancement"]},"bugfix":{"prefix":"🐛 Bug Fixes","labels":["bugfix"]},"refactor":{"prefix":"### 🐝  refactor","labels":["refactor"]},"chore":{"prefix":"### 🧰 Chore","labels":["chore"]},"Otherchanges":{"prefix":"✨ Other changes","labels":[""]},"dependencies":{"prefix":"⬆️ Dependency Updates","labels":["dependencies"]},"style":{"prefix":"🌈 Style","labels":["style"]}}'
->>>>>>> c3ddb29 (ci: workflow to generate changlog)
-=======
-          addSections: '{"documentation":{"prefix":"### 📖 Documentation","labels":["document"]},"Features":{"prefix":"### 🚀 Features","labels":["feature"]},"Enhancement":{"prefix":"### 🔥 Enhancement","labels":["enhancement"]},"bugfix":{"prefix":"🐛 Bug Fixes","labels":["bugfix"]},"refactor":{"prefix":"### 🐝  refactor","labels":["refactor"]},"chore":{"prefix":"### 🧰 Chore","labels":["chore"]},"Otherchanges":{"prefix":"✨ Other changes","labels":[""]},"dependencies":{"prefix":"⬆️ Dependency Updates","labels":["dependencies"]},"style":{"prefix":"🌈 Style","labels":["style"]}}'
->>>>>>> 0308bf9 (ci: update prefix image)
           author: true
           compareLink: true
           stripGeneratorNotice: true
@@ -42,18 +34,7 @@ jobs:
       with:
         token: ${{ secrets.TOKEN }}
         signoff: false
-<<<<<<< HEAD
-<<<<<<< HEAD
         commit-message: "docs: automated update CHANGELOG.md"
-        branch: bot-${{ github.repository }}
-        title: "docs: automated update CHANGELOG.md"
-        commit-message: "feat: automated pr to change config files"
-=======
-        commit-message: "docs: automated update CHANGELOG.mds"
->>>>>>> 94bbc12 (ci: update commit message)
-=======
-        commit-message: "docs: automated update CHANGELOG.md"
->>>>>>> 0308bf9 (ci: update prefix image)
         branch: bot-${{ github.repository }}
         title: "docs: automated update CHANGELOG.md"
         body: "automated pr to change log"

--- a/.github/workflows/generate_changlog_file.yml
+++ b/.github/workflows/generate_changlog_file.yml
@@ -47,5 +47,5 @@ jobs:
         commit-message: "docs: automated update CHANGELOG.mds"
 >>>>>>> 94bbc12 (ci: update commit message)
         branch: bot-${{ github.repository }}
-        title: "feat: automated pr to change log"
+        title: "docs: automated update CHANGELOG.md"
         body: "automated pr to change log"

--- a/.github/workflows/generate_changlog_file.yml
+++ b/.github/workflows/generate_changlog_file.yml
@@ -16,7 +16,11 @@ jobs:
       with:
           token: ${{ secrets.GITHUB_TOKEN }}
           headerLabel: "# 📑 Changelog"
+<<<<<<< HEAD
           addSections: '{"documentation":{"prefix":"### 📖 Documentation","labels":["document"]},"Features":{"prefix":"### 🚀 Features","labels":["feature"]},"Enhancement":{"prefix":"### 🔥 Enhancement","labels":["enhancement"]},"bugfix":{"prefix":"🐛 Bug Fixes","labels":["bugfix"]},"refactor":{"prefix":"### 🐝  refactor","labels":["refactor"]},"chore":{"prefix":"### 🧰 Chore","labels":["chore"]},"Otherchanges":{"prefix":"✨ Other changes","labels":[""]},"dependencies":{"prefix":"⬆️ Dependency Updates","labels":["dependencies"]},"style":{"prefix":"🌈 Style","labels":["style"]}}'
+=======
+          addSections: '{"documentation":{"prefix":"### 📖 Documentation","labels":["document"]},"Features":{"prefix":"### 🚀 Features","labels":["feature"]},"Enhancement":{"prefix":"### 🚀 Enhancement","labels":["enhancement"]},"bugfix":{"prefix":"🐛 Bug Fixes","labels":["bugfix"]},"refactor":{"prefix":"### 🐝  refactor","labels":["refactor"]},"chore":{"prefix":"### 🧰 Chore","labels":["chore"]},"Otherchanges":{"prefix":"✨ Other changes","labels":[""]},"dependencies":{"prefix":"⬆️ Dependency Updates","labels":["dependencies"]},"style":{"prefix":"🌈 Style","labels":["style"]}}'
+>>>>>>> c3ddb29 (ci: workflow to generate changlog)
           author: true
           compareLink: true
           stripGeneratorNotice: true
@@ -37,4 +41,7 @@ jobs:
         commit-message: "docs: automated update CHANGELOG.md"
         branch: bot-${{ github.repository }}
         title: "docs: automated update CHANGELOG.md"
+        commit-message: "feat: automated pr to change config files"
+        branch: bot-${{ github.repository }}
+        title: "feat: automated pr to change log"
         body: "automated pr to change log"

--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -17,18 +17,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: Namchee/conventional-pr@v0.12.1
-        # env:
-        #   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: Slashgear/action-check-pr-title@v4.3.0
         with:
-          # to override config-conventional rules, specify a relative path to your rules module, actions/checkout is required for this setting!
-          # commitlintRulesPath: "./commitlint.rules.js" # default: undefined
-          close: false
-          issue: false
-          message: 'The title of this PR does not conform the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please fix it, thx.'
-
-          # if the PR contains a single commit, fail if the commit message and the PR title do not match
-          access_token: ${{ secrets.GITHUB_TOKEN }}
+          regexp: "(feat|perf|refactor|fix|chore|docs|style|ci):" # Regex the title should match.
+          helpMessage: "The title of this PR does not conform the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please fix it, thx. Example: 'feat: example of title'"
+      - name: Check Commit Type
+        uses: gsactions/commit-message-checker@v2
+        with:
+          pattern: '(feat|perf|refactor|fix|chore|docs|style|ci):'
+          error: 'Your first line has to contain a commit type like "[BUGFIX]".'
+          
 
   Label:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -21,13 +21,7 @@ jobs:
         with:
           regexp: "(feat|perf|refactor|fix|chore|docs|style|ci):" # Regex the title should match.
           helpMessage: "The title of this PR does not conform the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please fix it, thx. Example: 'feat: example of title'"
-      - name: Check Commit Type
-        uses: gsactions/commit-message-checker@v2
-        with:
-          pattern: '(feat|perf|refactor|fix|chore|docs|style|ci):'
-          error: 'Your first line has to contain a commit type like "[BUGFIX]".'
           
-
   Label:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/remove_old_ci_caches.yml
+++ b/.github/workflows/remove_old_ci_caches.yml
@@ -1,0 +1,35 @@
+name: cleanup caches by a branch
+on:
+  # pull_request:
+  #   types:
+  #     - closed
+  push:
+
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
+          
+          REPO=${{ github.repository }}
+          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+     
+          echo "Fetching list of cache key"
+          cacheKeys=$(gh actions-cache list -R $REPO | cut -f 1 )
+          echo "cacheKeys are here" ${cacheKeys}
+          ## Setting this to not fail the workflow while deleting cache keys. 
+          # set +e
+          # echo "Deleting caches..."
+          # for cacheKey in $cacheKeysForPR
+          # do
+          #     gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          # done
+          # echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [ ] Cargo Clippy
- [ ] Coverage Test
- [ ] E2E Tests
- [ ] Code Format
- [ ] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
